### PR TITLE
Fix version handling

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        yq: [2.4.1, 3.4.1, v4.5.0]
+        yq: [2.4.1, 3.4.1, 4.5.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/bin/install
+++ b/bin/install
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
 install_yq() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  local version=$1
+  local install_path=$2
+  local platform
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/yq"
-  local download_url=$(get_download_url $version $platform)
+  local download_url
 
+  platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  download_url="$(get_download_url "${version}" "${platform}")"
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"
 
@@ -29,8 +29,16 @@ get_filename() {
 get_download_url() {
   local version="$1"
   local platform="$2"
-  local filename="$(get_filename $platform)"
+  local filename
+  local major
+  local minor
+  filename="$(get_filename "${platform}")"
+  major="$(echo "${version}" | cut -f1 -d.)"
+  minor="$(echo "${version}" | cut -f2 -d.)"
+  if [[ "${major}" -gt 4 || ("${major}" -eq 4 && "${minor}" -gt 0) ]] ; then
+    version="v${version}"
+  fi
   echo "https://github.com/mikefarah/yq/releases/download/${version}/${filename}"
 }
 
-install_yq $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_yq "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 release_path=https://api.github.com/repos/mikefarah/yq/releases
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+cmd='curl --fail --silent'
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+  cmd="${cmd} -H 'Authorization: token ${GITHUB_API_TOKEN}'"
 fi
 cmd="$cmd $release_path"
 
@@ -12,5 +14,7 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
-echo $versions
+eval "${cmd} '${release_path}'" |
+  jq '.[] | select(.prerelease == false) | .tag_name | sub("v"; "")' -r |
+  tac |
+  xargs echo


### PR DESCRIPTION
Handle the switch to `v` prefixed releases.
* Fixup shellcheck warnings.

Fixes: https://github.com/sudermanjr/asdf-yq/issues/1

Signed-off-by: Ben Kochie <superq@gmail.com>